### PR TITLE
[tap] #6 Execution pages: выровнять max-width и боковые отступы на diagnostics/runs/repos

### DIFF
--- a/apps/web/src/app/diagnostics/page.tsx
+++ b/apps/web/src/app/diagnostics/page.tsx
@@ -1,6 +1,7 @@
 import { Activity } from "lucide-react";
 
 import { HostDiagnosticsPanel } from "@/components/diagnostics/host-diagnostics-panel";
+import { ExecutionPageContainer } from "@/components/layout/execution-page-container";
 import { fetchHostReadiness } from "@/lib/api";
 import { t } from "@/lib/i18n";
 import { getRequestLocale } from "@/lib/i18n.server";
@@ -23,7 +24,7 @@ export default async function DiagnosticsPage() {
   }
 
   return (
-    <section className="space-y-6">
+    <ExecutionPageContainer>
       <div>
         <h1 className="mb-2 flex items-center gap-3 text-3xl font-black text-slate-900 dark:text-slate-50">
           <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-brand-100 text-brand-700 ring-1 ring-brand-200 dark:bg-zinc-800 dark:text-slate-200 dark:ring-zinc-700">
@@ -44,6 +45,6 @@ export default async function DiagnosticsPage() {
         initialSnapshot={initialSnapshot}
         locale={locale}
       />
-    </section>
+    </ExecutionPageContainer>
   );
 }

--- a/apps/web/src/app/repos/[owner]/[repo]/issues/[number]/page.tsx
+++ b/apps/web/src/app/repos/[owner]/[repo]/issues/[number]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { ArrowLeft, ExternalLink, MessageSquareText, PlaySquare } from "lucide-react";
 
 import { GitHubIssueTrackerPanel } from "@/components/github/github-issue-tracker-panel";
+import { ExecutionPageContainer } from "@/components/layout/execution-page-container";
 import { fetchGitHubIssue, fetchGitHubRepo } from "@/lib/api";
 import { t } from "@/lib/i18n";
 import { getRequestLocale } from "@/lib/i18n.server";
@@ -34,7 +35,7 @@ export default async function RepoIssuePage({
   }
 
   return (
-    <section className="space-y-6">
+    <ExecutionPageContainer>
       <Link
         className="inline-flex items-center gap-2 text-sm font-semibold text-brand-700 hover:text-brand-800 dark:text-brand-300 dark:hover:text-brand-200"
         href={`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}`}
@@ -111,6 +112,6 @@ export default async function RepoIssuePage({
           />
         </>
       )}
-    </section>
+    </ExecutionPageContainer>
   );
 }

--- a/apps/web/src/app/repos/[owner]/[repo]/page.tsx
+++ b/apps/web/src/app/repos/[owner]/[repo]/page.tsx
@@ -9,6 +9,7 @@ import {
   PlaySquare
 } from "lucide-react";
 
+import { ExecutionPageContainer } from "@/components/layout/execution-page-container";
 import {
   fetchGitHubRepo,
   fetchGitHubRepoIssues,
@@ -116,7 +117,7 @@ export default async function RepoDetailsPage({
 
   if (repoError || !repo) {
     return (
-      <section className="space-y-6">
+      <ExecutionPageContainer>
         <Link
           className="inline-flex items-center gap-2 text-sm font-semibold text-brand-700 hover:text-brand-800 dark:text-brand-300 dark:hover:text-brand-200"
           href="/repos"
@@ -127,12 +128,12 @@ export default async function RepoDetailsPage({
         <div className="rounded-3xl border border-rose-200 bg-rose-50 px-5 py-4 text-sm text-rose-700 dark:border-rose-900/70 dark:bg-rose-950/40 dark:text-rose-200">
           {repoError}
         </div>
-      </section>
+      </ExecutionPageContainer>
     );
   }
 
   return (
-    <section className="space-y-6">
+    <ExecutionPageContainer>
       <div className="space-y-3">
         <Link
           className="inline-flex items-center gap-2 text-sm font-semibold text-brand-700 hover:text-brand-800 dark:text-brand-300 dark:hover:text-brand-200"
@@ -431,6 +432,6 @@ export default async function RepoDetailsPage({
           </div>
         ) : null}
       </div>
-    </section>
+    </ExecutionPageContainer>
   );
 }

--- a/apps/web/src/app/repos/[owner]/[repo]/pulls/[number]/page.tsx
+++ b/apps/web/src/app/repos/[owner]/[repo]/pulls/[number]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ArrowLeft, ExternalLink, GitBranch, ShieldCheck } from "lucide-react";
 
+import { ExecutionPageContainer } from "@/components/layout/execution-page-container";
 import { fetchGitHubPull, fetchGitHubPullChecks, fetchGitHubRepo } from "@/lib/api";
 import { t } from "@/lib/i18n";
 import { getRequestLocale } from "@/lib/i18n.server";
@@ -51,7 +52,7 @@ export default async function RepoPullPage({
   }
 
   return (
-    <section className="space-y-6">
+    <ExecutionPageContainer>
       <Link
         className="inline-flex items-center gap-2 text-sm font-semibold text-brand-700 hover:text-brand-800 dark:text-brand-300 dark:hover:text-brand-200"
         href={`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}`}
@@ -241,6 +242,6 @@ export default async function RepoPullPage({
           </div>
         </>
       )}
-    </section>
+    </ExecutionPageContainer>
   );
 }

--- a/apps/web/src/app/repos/page.tsx
+++ b/apps/web/src/app/repos/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ExternalLink, FolderGit2, GitBranch, Search } from "lucide-react";
 
+import { ExecutionPageContainer } from "@/components/layout/execution-page-container";
 import { fetchGitHubRepos } from "@/lib/api";
 import { t } from "@/lib/i18n";
 import { getRequestLocale } from "@/lib/i18n.server";
@@ -41,7 +42,7 @@ export default async function ReposPage({
   }
 
   return (
-    <section className="space-y-6">
+    <ExecutionPageContainer>
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <h1 className="mb-2 flex items-center gap-3 text-3xl font-black text-slate-900 dark:text-slate-50">
@@ -163,6 +164,6 @@ export default async function ReposPage({
           ))}
         </div>
       ) : null}
-    </section>
+    </ExecutionPageContainer>
   );
 }

--- a/apps/web/src/app/runs/[id]/page.tsx
+++ b/apps/web/src/app/runs/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ArrowLeft, PlaySquare } from "lucide-react";
 
+import { ExecutionPageContainer } from "@/components/layout/execution-page-container";
 import { RunDetailsPanel } from "@/components/runs/run-details-panel";
 import { t } from "@/lib/i18n";
 import { getRequestLocale } from "@/lib/i18n.server";
@@ -9,7 +10,7 @@ export default function RunDetailsPage({ params }: { params: { id: string } }) {
   const locale = getRequestLocale();
 
   return (
-    <section className="space-y-6">
+    <ExecutionPageContainer>
       <div className="space-y-3">
         <Link
           className="inline-flex items-center gap-2 text-sm font-semibold text-brand-700 hover:text-brand-800 dark:text-brand-300 dark:hover:text-brand-200"
@@ -27,6 +28,6 @@ export default function RunDetailsPage({ params }: { params: { id: string } }) {
       </div>
 
       <RunDetailsPanel locale={locale} runId={params.id} />
-    </section>
+    </ExecutionPageContainer>
   );
 }

--- a/apps/web/src/app/runs/new/page.tsx
+++ b/apps/web/src/app/runs/new/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ArrowLeft, PlaySquare } from "lucide-react";
 
+import { ExecutionPageContainer } from "@/components/layout/execution-page-container";
 import { RunLaunchForm } from "@/components/runs/run-launch-form";
 import { fetchGitHubRepos, fetchHostReadiness, fetchTeams } from "@/lib/api";
 import { t } from "@/lib/i18n";
@@ -36,7 +37,7 @@ export default async function NewRunPage({
   const issueNumber = issueRaw ? Number(issueRaw) : undefined;
 
   return (
-    <section className="space-y-6">
+    <ExecutionPageContainer>
       <div className="space-y-3">
         <Link
           className="inline-flex items-center gap-2 text-sm font-semibold text-brand-700 hover:text-brand-800 dark:text-brand-300 dark:hover:text-brand-200"
@@ -71,6 +72,6 @@ export default async function NewRunPage({
         suggestedRepos={repos}
         teams={teams}
       />
-    </section>
+    </ExecutionPageContainer>
   );
 }

--- a/apps/web/src/app/runs/page.tsx
+++ b/apps/web/src/app/runs/page.tsx
@@ -1,5 +1,6 @@
 import { PlaySquare } from "lucide-react";
 
+import { ExecutionPageContainer } from "@/components/layout/execution-page-container";
 import { RunsListPanel } from "@/components/runs/runs-list-panel";
 import { t } from "@/lib/i18n";
 import { getRequestLocale } from "@/lib/i18n.server";
@@ -8,7 +9,7 @@ export default function RunsPage() {
   const locale = getRequestLocale();
 
   return (
-    <section className="space-y-6">
+    <ExecutionPageContainer>
       <div>
         <h1 className="mb-2 flex items-center gap-3 text-3xl font-black text-slate-900 dark:text-slate-50">
           <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-brand-100 text-brand-700 ring-1 ring-brand-200 dark:bg-zinc-800 dark:text-slate-200 dark:ring-zinc-700">
@@ -25,6 +26,6 @@ export default function RunsPage() {
       </div>
 
       <RunsListPanel locale={locale} />
-    </section>
+    </ExecutionPageContainer>
   );
 }

--- a/apps/web/src/components/layout/execution-page-container.tsx
+++ b/apps/web/src/components/layout/execution-page-container.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type ExecutionPageContainerProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function ExecutionPageContainer({ children, className }: ExecutionPageContainerProps) {
+  return <section className={cn("mx-auto w-full max-w-[1200px] space-y-6", className)}>{children}</section>;
+}


### PR DESCRIPTION
## Team Agent Platform run

- Team: `Fullstack Delivery Squad`
- Repository: `stemirkhan/team-agent-platform`
- Base branch: `main`
- Working branch: `tap/team-agent-platform/20260309170511-52fac8`
- Issue: #6
- Issue URL: https://github.com/stemirkhan/team-agent-platform/issues/6

## Summary
[2m2026-03-09T17:20:46.615547Z[0m [33m WARN[0m [2mcodex_core::file_watcher[0m[2m:[0m failed to unwatch /home/temirkhan/.team-agent-platform/workspaces/d46fb77ceead407b99f4727ae009b55e/codex-home/skills/.system: No watch was found. about ["/home/temirkhan/.team-agent-platform/workspaces/d46fb77ceead407b99f4727ae009b55e/codex-home/skills/.system"]

## Notes
- This draft PR was created by the local host-execution flow.
- Review the diff and run project-specific checks before merging.