### PR TITLE
[tap] #12 Board: compact empty columns on execution board

### DIFF
--- a/apps/web/src/components/projects/execution-board-panel.tsx
+++ b/apps/web/src/components/projects/execution-board-panel.tsx
@@ -27,7 +27,6 @@ type BoardColumn = {
   key: RunsBoardLane;
   title: string;
   description: string;
-  emptyLabel: string;
   statuses: RunStatus[];
   columnClassName: string;
 };
@@ -55,10 +54,6 @@ function buildBoardColumns(locale: Locale): BoardColumn[] {
         ru: "Run создан и проходит подготовительные шаги.",
         en: "Runs that were created and are still moving through preparation."
       }),
-      emptyLabel: t(locale, {
-        ru: "Нет запусков в очереди.",
-        en: "No queued runs."
-      }),
       statuses: laneStatusMap.queued,
       columnClassName:
         "border-slate-200 bg-slate-50/70 dark:border-zinc-800 dark:bg-zinc-900/70"
@@ -69,10 +64,6 @@ function buildBoardColumns(locale: Locale): BoardColumn[] {
       description: t(locale, {
         ru: "Setup, Codex execution и checks идут прямо сейчас.",
         en: "Setup, Codex execution, and checks are currently in progress."
-      }),
-      emptyLabel: t(locale, {
-        ru: "Сейчас ничего не выполняется.",
-        en: "Nothing is actively executing right now."
       }),
       statuses: laneStatusMap.active,
       columnClassName:
@@ -85,10 +76,6 @@ function buildBoardColumns(locale: Locale): BoardColumn[] {
         ru: "Run уже выходит из Codex и оформляет git/PR слой.",
         en: "Codex is done and the run is finishing the git and PR layer."
       }),
-      emptyLabel: t(locale, {
-        ru: "Нет запусков на финализации.",
-        en: "No runs are in the finalization phase."
-      }),
       statuses: laneStatusMap.finalizing,
       columnClassName:
         "border-amber-200 bg-amber-50/70 dark:border-amber-500/20 dark:bg-amber-500/5"
@@ -100,10 +87,6 @@ function buildBoardColumns(locale: Locale): BoardColumn[] {
         ru: "Успешно завершенные исполнения.",
         en: "Runs that completed successfully."
       }),
-      emptyLabel: t(locale, {
-        ru: "Успешных запусков пока нет.",
-        en: "There are no completed runs yet."
-      }),
       statuses: laneStatusMap.completed,
       columnClassName:
         "border-sky-200 bg-sky-50/70 dark:border-sky-500/20 dark:bg-sky-500/5"
@@ -114,10 +97,6 @@ function buildBoardColumns(locale: Locale): BoardColumn[] {
       description: t(locale, {
         ru: "Прерванные, упавшие или отмененные запуски.",
         en: "Runs that were interrupted, failed, or cancelled."
-      }),
-      emptyLabel: t(locale, {
-        ru: "Нет прерванных, упавших или отмененных запусков.",
-        en: "No interrupted, failed, or cancelled runs."
       }),
       statuses: laneStatusMap.failed,
       columnClassName:
@@ -420,44 +399,48 @@ export function ExecutionBoardPanel({ locale }: ExecutionBoardPanelProps) {
 
       {user && totalRuns > 0 ? (
         <div className="grid gap-4 xl:grid-cols-5 xl:items-start">
-          {boardColumns.map((column) => (
-            <section
-              className={cn(
-                "flex min-h-[18rem] self-start flex-col rounded-3xl border p-4",
-                column.columnClassName
-              )}
-              key={column.key}
-            >
-              <div className="mb-4">
-                <div className="flex items-center justify-between gap-2">
-                  <h3 className="text-lg font-black text-slate-900 dark:text-slate-50">
-                    {column.title}
-                  </h3>
-                  <span className="rounded-full bg-white/80 px-2.5 py-1 text-xs font-semibold text-slate-700 ring-1 ring-black/5 dark:bg-zinc-950/80 dark:text-slate-200 dark:ring-white/10">
-                    {groupedRuns[column.key].length}
-                  </span>
-                </div>
-                <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">{column.description}</p>
-              </div>
+          {boardColumns.map((column) => {
+            const columnRuns = groupedRuns[column.key];
+            const hasRuns = columnRuns.length > 0;
 
-              <div className="space-y-3">
-                {groupedRuns[column.key].length === 0 ? (
-                  <div className="rounded-2xl border border-dashed border-slate-300/80 bg-white/60 px-4 py-4 text-sm text-slate-500 dark:border-zinc-700 dark:bg-zinc-950/40 dark:text-slate-400">
-                    {column.emptyLabel}
+            return (
+              <section
+                className={cn(
+                  "flex self-start flex-col rounded-3xl border p-4",
+                  hasRuns ? "min-h-[18rem]" : "min-h-0",
+                  column.columnClassName
+                )}
+                key={column.key}
+              >
+                <div className={cn(hasRuns ? "mb-4" : "mb-0")}>
+                  <div className="flex items-center justify-between gap-2">
+                    <h3 className="text-lg font-black text-slate-900 dark:text-slate-50">
+                      {column.title}
+                    </h3>
+                    <span className="rounded-full bg-white/80 px-2.5 py-1 text-xs font-semibold text-slate-700 ring-1 ring-black/5 dark:bg-zinc-950/80 dark:text-slate-200 dark:ring-white/10">
+                      {columnRuns.length}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+                    {column.description}
+                  </p>
+                </div>
+
+                {hasRuns ? (
+                  <div className="space-y-3">
+                    {columnRuns.map((run) => (
+                      <ExecutionBoardCard
+                        key={run.id}
+                        locale={locale}
+                        run={run}
+                        showRepository={selectedRepository === "all"}
+                      />
+                    ))}
                   </div>
                 ) : null}
-
-                {groupedRuns[column.key].map((run) => (
-                  <ExecutionBoardCard
-                    key={run.id}
-                    locale={locale}
-                    run={run}
-                    showRepository={selectedRepository === "all"}
-                  />
-                ))}
-              </div>
-            </section>
-          ))}
+              </section>
+            );
+          })}
         </div>
       ) : null}
     </section>


### PR DESCRIPTION
## Team Agent Platform run

- Team: `Fullstack Delivery Squad`
- Repository: `stemirkhan/team-agent-platform`
- Base branch: `main`
- Working branch: `tap/team-agent-platform/20260313161625-fb1a27`
- Issue: #12
- Issue URL: https://github.com/stemirkhan/team-agent-platform/issues/12

## Summary
Updated the execution board so empty lanes stay compact in [apps/web/src/components/projects/execution-board-panel.tsx](/home/temirkhan/.team-agent-platform/workspaces/69c60127b97f4a299878f9e5adc85ebd/repo/apps/web/src/components/projects/execution-board-panel.tsx#L26) and [apps/web/src/components/projects/execution-board-panel.tsx](/home/temirkhan/.team-agent-platform/workspaces/69c60127b97f4a299878f9e5adc85ebd/repo/apps/web/src/components/projects/execution-board-panel.tsx#L400). I removed the per-column dashed empty-state panel, dropped the now-unused `emptyLabel` field, and made lane height conditional so populated columns keep the taller card area while zero-card columns render just the header, count badge, and description.

Validation:
- `make compose-config`
- `cd apps/backend && .venv/bin/python -m ruff check app tests`
- `cd apps/web && npm run lint`

`cd apps/backend && .venv/bin/python -m pytest -q` did not complete in this environment and had to be interrupted after hanging without output, so that check is still outstanding. The next logical step is a quick manual check of the execution board on desktop and mobile widths to confirm the compact empty columns look balanced with mixed populated/empty lanes.

## Notes
- This draft PR was created by the local host-execution flow.
- Review the diff and run project-specific checks before merging.