### PR TITLE
[tap] #19 Runs: derive token usage when terminal lacks turn.completed

### DIFF
--- a/apps/backend/app/models/run.py
+++ b/apps/backend/app/models/run.py
@@ -104,6 +104,24 @@ class Run(Base):
         lazy="selectin",
     )
 
+    @property
+    def input_tokens(self) -> int | None:
+        """Transient token-usage value attached during read serialization."""
+        return getattr(self, "_input_tokens", None)
+
+    @input_tokens.setter
+    def input_tokens(self, value: int | None) -> None:
+        self._input_tokens = value
+
+    @property
+    def output_tokens(self) -> int | None:
+        """Transient token-usage value attached during read serialization."""
+        return getattr(self, "_output_tokens", None)
+
+    @output_tokens.setter
+    def output_tokens(self, value: int | None) -> None:
+        self._output_tokens = value
+
 
 class RunEvent(Base):
     """Persistent non-terminal event emitted during run orchestration."""

--- a/apps/backend/app/schemas/run.py
+++ b/apps/backend/app/schemas/run.py
@@ -106,6 +106,8 @@ class RunRead(BaseModel):
     transport_ref: str | None = None
     resume_attempt_count: int = 0
     interrupted_at: datetime | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
     status: RunStatus
     error_message: str | None = None
     pr_url: str | None = None

--- a/apps/backend/app/services/run_service.py
+++ b/apps/backend/app/services/run_service.py
@@ -325,7 +325,7 @@ class RunService:
             status=status_value,
             repo_full_name=normalized_repo_full_name,
         )
-        items = [self._sync_run_with_codex_session(item) for item in items]
+        items = [self._enrich_run_for_read(item) for item in items]
         return RunListResponse(items=items, total=total, limit=limit, offset=offset)
 
     def get_run(self, run_id, current_user: User):
@@ -334,7 +334,7 @@ class RunService:
         if run is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Run not found.")
         self._ensure_owner(run.created_by, current_user.id)
-        run = self._sync_run_with_codex_session(run)
+        run = self._enrich_run_for_read(run)
         run.run_report = self._build_run_report(run)
         return run
 
@@ -1114,6 +1114,31 @@ class RunService:
             payload={"detail": updated.error_message},
         )
         return updated
+
+    def _enrich_run_for_read(self, run):
+        """Attach best-effort session usage before serializing a run."""
+        run = self._sync_run_with_codex_session(run)
+        session = self._best_effort_get_session(run)
+        if session is not None:
+            self._attach_run_usage(run, session)
+        else:
+            self._attach_run_usage(run, None)
+        return run
+
+    def _best_effort_get_session(self, run) -> CodexSessionRead | None:
+        """Return host-side session metadata when it is available for one run."""
+        if not run.workspace_id:
+            return None
+        try:
+            return self.codex_proxy_service.get_session(str(run.id))
+        except CodexProxyServiceError:
+            return None
+
+    @staticmethod
+    def _attach_run_usage(run, session: CodexSessionRead | None) -> None:
+        """Mirror token usage onto the run read model for API serialization."""
+        run.input_tokens = session.input_tokens if session is not None else None
+        run.output_tokens = session.output_tokens if session is not None else None
 
     @staticmethod
     def _build_run_session_fields(session: CodexSessionRead) -> dict[str, object]:

--- a/apps/backend/tests/test_run_usage.py
+++ b/apps/backend/tests/test_run_usage.py
@@ -1,0 +1,92 @@
+"""Focused tests for run token-usage enrichment."""
+
+from types import SimpleNamespace
+
+from app.schemas.codex import CodexSessionRead
+from app.schemas.run import RunRead
+from app.services.run_service import RunService
+
+
+def test_enrich_run_for_read_attaches_session_usage_without_turn_completed() -> None:
+    """Completed-session usage should be exposed on the run read model."""
+    run = SimpleNamespace(
+        id="run-1",
+        workspace_id="ws-1",
+        input_tokens=None,
+        output_tokens=None,
+    )
+    session = CodexSessionRead(
+        run_id="run-1",
+        workspace_id="ws-1",
+        repo_path="/tmp/ws-1/repo",
+        command=["codex", "exec", "--json"],
+        status="completed",
+        exit_code=0,
+        summary_text="done",
+        input_tokens=987,
+        output_tokens=65,
+        started_at="2026-03-08T10:06:00Z",
+        finished_at="2026-03-08T10:08:00Z",
+        last_output_offset=3,
+    )
+    service = RunService(
+        run_repository=SimpleNamespace(),
+        team_repository=SimpleNamespace(),
+        export_service=SimpleNamespace(),
+        workspace_proxy_service=SimpleNamespace(),
+        codex_proxy_service=SimpleNamespace(get_session=lambda run_id: session),
+        github_proxy_service=SimpleNamespace(),
+        readiness_service=SimpleNamespace(),
+    )
+    service._sync_run_with_codex_session = lambda current_run: current_run
+
+    enriched = service._enrich_run_for_read(run)
+
+    assert enriched.input_tokens == 987
+    assert enriched.output_tokens == 65
+
+
+def test_run_read_schema_includes_usage_fields() -> None:
+    """RunRead should serialize token usage from enriched run objects."""
+    payload = RunRead.model_validate(
+        SimpleNamespace(
+            id="4b8efb16-f6f0-4ac1-bfea-42b3d3df6168",
+            team_id=None,
+            team_slug="delivery-team",
+            team_title="Delivery Team",
+            runtime_target="codex",
+            repo_owner="stemirkhan",
+            repo_name="team-agent-platform",
+            repo_full_name="stemirkhan/team-agent-platform",
+            base_branch="main",
+            working_branch="tap/team-agent-platform/demo-branch",
+            issue_number=None,
+            issue_title=None,
+            issue_url=None,
+            title="Expose usage fallback",
+            summary=None,
+            task_text="Run codex and expose usage fallback.",
+            runtime_config_json=None,
+            workspace_id="ws-1",
+            workspace_path="/tmp/ws-1",
+            repo_path="/tmp/ws-1/repo",
+            codex_session_id="session-1",
+            transport_kind="pty",
+            transport_ref="12345",
+            resume_attempt_count=0,
+            interrupted_at=None,
+            input_tokens=987,
+            output_tokens=65,
+            status="completed",
+            error_message=None,
+            pr_url=None,
+            started_at=None,
+            finished_at=None,
+            created_at="2026-03-08T10:00:00Z",
+            updated_at="2026-03-08T10:10:00Z",
+            run_report=None,
+        )
+    )
+
+    assert payload.input_tokens == 987
+    assert payload.output_tokens == 65

--- a/apps/host-executor/host_executor_app/services/codex_session_service.py
+++ b/apps/host-executor/host_executor_app/services/codex_session_service.py
@@ -1228,14 +1228,19 @@ class CodexSessionService:
         cls,
         chunks: list[CodexTerminalChunk],
     ) -> tuple[int | None, int | None]:
-        """Return the latest token usage reported by Codex turn completion events."""
+        """Return the latest token usage from structured Codex events."""
         input_tokens: int | None = None
         output_tokens: int | None = None
+        strongest_source = 0
 
         for payload in cls._iter_json_objects(chunks):
             parsed = cls._extract_usage_from_payload(payload)
             if parsed is not None:
-                input_tokens, output_tokens = parsed
+                source_rank, next_input_tokens, next_output_tokens = parsed
+                if source_rank < strongest_source:
+                    continue
+                strongest_source = source_rank
+                input_tokens, output_tokens = next_input_tokens, next_output_tokens
 
         return input_tokens, output_tokens
 
@@ -1252,16 +1257,17 @@ class CodexSessionService:
 
         if not isinstance(payload, dict):
             return None
-        return cls._extract_usage_from_payload(payload)
+        parsed = cls._extract_usage_from_payload(payload)
+        if parsed is None:
+            return None
+        _, input_tokens, output_tokens = parsed
+        return input_tokens, output_tokens
 
     @staticmethod
     def _extract_usage_from_payload(
         payload: dict[str, object]
-    ) -> tuple[int | None, int | None] | None:
-        """Return token usage from one parsed turn.completed payload when available."""
-        if payload.get("type") != "turn.completed":
-            return None
-
+    ) -> tuple[int, int | None, int | None] | None:
+        """Return token usage from one parsed payload when structured usage exists."""
         usage = payload.get("usage")
         if not isinstance(usage, dict):
             return None
@@ -1274,7 +1280,8 @@ class CodexSessionService:
 
         if input_tokens is None and output_tokens is None:
             return None
-        return input_tokens, output_tokens
+        source_rank = 2 if payload.get("type") == "turn.completed" else 1
+        return source_rank, input_tokens, output_tokens
 
     @classmethod
     def _derive_codex_session_id(cls, chunks: list[CodexTerminalChunk]) -> str | None:

--- a/apps/host-executor/tests/test_codex_session_service.py
+++ b/apps/host-executor/tests/test_codex_session_service.py
@@ -300,6 +300,66 @@ def test_get_session_exposes_latest_token_usage(tmp_path, monkeypatch) -> None:
     assert session.output_tokens == 23804
 
 
+def test_get_session_falls_back_to_structured_usage_without_turn_completed(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Structured usage payloads should backfill token usage when turn.completed is absent."""
+    monkeypatch.setattr(
+        workspace_service_module,
+        "get_settings",
+        lambda: SimpleNamespace(workspace_root=str(tmp_path / "workspaces")),
+    )
+    service = CodexSessionService()
+
+    storage_dir = service.sessions_root / "run-usage-fallback"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    (storage_dir / "session.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-usage-fallback",
+                "workspace_id": "ws-usage-fallback",
+                "repo_path": "/tmp/ws-usage-fallback/repo",
+                "command": ["codex", "exec", "--json"],
+                "status": "completed",
+                "pid": 101,
+                "exit_code": 0,
+                "error_message": None,
+                "summary_text": "done",
+                "codex_session_id": None,
+                "transport_kind": "pty",
+                "transport_ref": "101",
+                "resume_attempt_count": 0,
+                "interrupted_at": None,
+                "resumable": False,
+                "recovered_from_restart": False,
+                "started_at": "2026-03-09T10:00:00Z",
+                "finished_at": "2026-03-09T10:05:00Z",
+                "last_output_offset": 1,
+            },
+            ensure_ascii=True,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    with (storage_dir / "chunks.jsonl").open("w", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                CodexTerminalChunk(
+                    offset=0,
+                    text='{"type":"session.completed","usage":{"input_tokens":987,"output_tokens":65}}\n',
+                    created_at="2026-03-09T10:05:00Z",
+                ).model_dump(),
+                ensure_ascii=True,
+            )
+        )
+        handle.write("\n")
+
+    session = service.get_session("run-usage-fallback")
+    assert session.input_tokens == 987
+    assert session.output_tokens == 65
+
+
 def test_resume_session_restarts_interrupted_session(tmp_path, monkeypatch) -> None:
     """Interrupted sessions should restart through `codex exec resume`."""
     monkeypatch.setattr(

--- a/apps/web/src/components/runs/run-details-panel.tsx
+++ b/apps/web/src/components/runs/run-details-panel.tsx
@@ -787,10 +787,12 @@ export function RunDetailsPanel({ locale, runId }: RunDetailsPanelProps) {
   ];
   const durationLabel = formatRunDuration(locale, run.started_at, run.finished_at, nowMs);
   const latestEvent = events[0] ?? null;
-  const inputTokensLabel = formatCompactNumber(locale, terminalSession?.input_tokens ?? null);
-  const outputTokensLabel = formatCompactNumber(locale, terminalSession?.output_tokens ?? null);
-  const inputTokensCompactLabel = formatAbbreviatedNumber(locale, terminalSession?.input_tokens ?? null);
-  const outputTokensCompactLabel = formatAbbreviatedNumber(locale, terminalSession?.output_tokens ?? null);
+  const inputTokens = run.input_tokens ?? terminalSession?.input_tokens ?? null;
+  const outputTokens = run.output_tokens ?? terminalSession?.output_tokens ?? null;
+  const inputTokensLabel = formatCompactNumber(locale, inputTokens);
+  const outputTokensLabel = formatCompactNumber(locale, outputTokens);
+  const inputTokensCompactLabel = formatAbbreviatedNumber(locale, inputTokens);
+  const outputTokensCompactLabel = formatAbbreviatedNumber(locale, outputTokens);
 
   const renderOverview = () => (
     <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
@@ -1279,8 +1281,8 @@ export function RunDetailsPanel({ locale, runId }: RunDetailsPanelProps) {
                 <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
                   {terminalSession
                     ? t(locale, {
-                        ru: "Берется из последнего turn.completed в terminal stream.",
-                        en: "Derived from the latest turn.completed event in the terminal stream."
+                        ru: "Берется из структурированных данных использования Codex-сессии.",
+                        en: "Derived from structured Codex session usage data."
                       })
                     : t(locale, {
                         ru: "Появится после старта Codex-сессии.",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -162,6 +162,8 @@ export type Run = {
   transport_ref: string | null;
   resume_attempt_count: number;
   interrupted_at: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
   status: RunStatus;
   error_message: string | null;
   pr_url: string | null;


### PR DESCRIPTION
## Team Agent Platform run

- Team: `Fullstack Delivery Squad`
- Repository: `stemirkhan/team-agent-platform`
- Base branch: `main`
- Working branch: `tap/team-agent-platform/20260314154453-2130c8`
- Issue: #19
- Issue URL: https://github.com/stemirkhan/team-agent-platform/issues/19

## Summary
Implemented the fallback path for run token usage and wired the UI to use it.

On the host-executor side, [`codex_session_service.py`](/home/temirkhan/.team-agent-platform/workspaces/b3f4ebe913d24e7493e9ec580c67b448/repo/apps/host-executor/host_executor_app/services/codex_session_service.py) now accepts structured `usage` payloads even when `turn.completed` is missing, while still preferring `turn.completed` when it exists. On the backend, [`run.py`](/home/temirkhan/.team-agent-platform/workspaces/b3f4ebe913d24e7493e9ec580c67b448/repo/apps/backend/app/models/run.py), [`run.py`](/home/temirkhan/.team-agent-platform/workspaces/b3f4ebe913d24e7493e9ec580c67b448/repo/apps/backend/app/schemas/run.py), and [`run_service.py`](/home/temirkhan/.team-agent-platform/workspaces/b3f4ebe913d24e7493e9ec580c67b448/repo/apps/backend/app/services/run_service.py) now expose `input_tokens` and `output_tokens` on run reads via best-effort session enrichment. On the frontend, [`api.ts`](/home/temirkhan/.team-agent-platform/workspaces/b3f4ebe913d24e7493e9ec580c67b448/repo/apps/web/src/lib/api.ts) and [`run-details-panel.tsx`](/home/temirkhan/.team-agent-platform/workspaces/b3f4ebe913d24e7493e9ec580c67b448/repo/apps/web/src/components/runs/run-details-panel.tsx) now prefer run-level usage and use neutral copy instead of claiming it always comes from `turn.completed`.

Tests added in [`test_run_usage.py`](/home/temirkhan/.team-agent-platform/workspaces/b3f4ebe913d24e7493e9ec580c67b448/repo/apps/backend/tests/test_run_usage.py) and [`test_codex_session_service.py`](/home/temirkhan/.team-agent-platform/workspaces/b3f4ebe913d24e7493e9ec580c67b448/repo/apps/host-executor/tests/test_codex_session_service.py) cover the fallback path.

Validation:
- `make compose-config`
- `cd apps/backend && .venv/bin/python -m ruff check app tests`
- `cd apps/backend && .venv/bin/python -m pytest -q tests/test_run_usage.py`
- `cd apps/web && npm run lint`
- `cd apps/host-executor && ../backend/.venv/bin/python -m pytest -q tests/test_codex_session_service.py`

The configured full backend suite command, `cd apps/backend && .venv/bin/python -m pytest -q`, did not complete in this environment and timed out after 60 seconds with no output, so I validated the relevant backend and host-executor tests directly.

Most logical next step: reproduce one completed run without `turn.completed` in the app and confirm the overview token card now shows the fallback values instead of `-`.

## Notes
- This draft PR was created by the local host-execution flow.
- Review the diff and run project-specific checks before merging.