### PR TITLE
[tap] #20 Runs: add Run again action from an existing run

### DIFF
--- a/apps/backend/app/api/v1/runs.py
+++ b/apps/backend/app/api/v1/runs.py
@@ -87,6 +87,16 @@ def resume_run(
     return service.resume_run(run_id, user)
 
 
+@router.post("/{run_id}/rerun", response_model=RunRead, status_code=status.HTTP_201_CREATED)
+def rerun_run(
+    run_id: UUID,
+    user: User = Depends(get_current_user),
+    service: RunService = Depends(get_run_service),
+) -> RunRead:
+    """Create one fresh run from an existing terminal run context."""
+    return service.rerun_run(run_id, user)
+
+
 @router.get("/{run_id}/terminal/session", response_model=CodexSessionRead)
 def get_run_terminal_session(
     run_id: UUID,

--- a/apps/backend/app/services/run_service.py
+++ b/apps/backend/app/services/run_service.py
@@ -466,6 +466,34 @@ class RunService:
         )
         return run
 
+    def rerun_run(self, run_id, current_user: User):
+        """Create a fresh run from one finished run context."""
+        run = self.get_run(run_id, current_user)
+        if run.status not in {
+            RunStatus.COMPLETED.value,
+            RunStatus.FAILED.value,
+            RunStatus.CANCELLED.value,
+        }:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "Only completed, failed, or cancelled runs can be run again. "
+                    "Use resume for interrupted runs."
+                ),
+            )
+
+        rerun = self.create_run(self._build_rerun_payload(run), current_user)
+        self._append_event(
+            run_id=rerun.id,
+            event_type=RunEventType.NOTE,
+            payload={
+                "kind": "rerun",
+                "message": "This run was created from an earlier run context.",
+                "source_run_id": str(run.id),
+            },
+        )
+        return rerun
+
     def get_terminal_session(self, run_id, current_user: User) -> CodexSessionRead:
         """Return current host-side terminal session for one run."""
         run = self.get_run(run_id, current_user)
@@ -732,6 +760,27 @@ class RunService:
             first_line = payload.task_text.strip().splitlines()[0]
             return first_line[:4000]
         return None
+
+    @staticmethod
+    def _build_rerun_payload(run) -> RunCreate:
+        """Reconstruct one fresh run payload from persisted run context."""
+        codex_config = None
+        if isinstance(run.runtime_config_json, dict):
+            raw_codex = run.runtime_config_json.get("codex")
+            if isinstance(raw_codex, dict):
+                codex_config = CodexExportOptions.model_validate(raw_codex)
+
+        return RunCreate(
+            team_slug=run.team_slug,
+            repo_owner=run.repo_owner,
+            repo_name=run.repo_name,
+            base_branch=run.base_branch,
+            issue_number=run.issue_number,
+            task_text=run.task_text,
+            title=run.title,
+            summary=run.summary,
+            codex=codex_config,
+        )
 
     def _append_event(
         self,

--- a/apps/backend/tests/test_runs_api.py
+++ b/apps/backend/tests/test_runs_api.py
@@ -435,6 +435,19 @@ def test_create_run_returns_failed_state_when_workspace_prepare_breaks(
         "get_execution_config",
         lambda self, workspace_id: _execution_config(),
     )
+    monkeypatch.setattr(
+        WorkspaceProxyService,
+        "get_workspace",
+        lambda self, workspace_id: _workspace().model_copy(
+            update={
+                "id": workspace_id,
+                "workspace_path": f"/tmp/{workspace_id}",
+                "repo_path": f"/tmp/{workspace_id}/repo",
+                "working_branch": f"tap/team-agent-platform/{workspace_id}",
+                "current_branch": f"tap/team-agent-platform/{workspace_id}",
+            }
+        ),
+    )
 
     create_response = client.post(
         "/api/v1/runs",
@@ -1098,6 +1111,17 @@ def test_get_run_completes_without_commit_when_only_materialized_files_changed(
     )
     monkeypatch.setattr(
         WorkspaceProxyService,
+        "get_workspace",
+        lambda self, workspace_id: _workspace().model_copy(
+            update={
+                "id": workspace_id,
+                "workspace_path": f"/tmp/{workspace_id}",
+                "repo_path": f"/tmp/{workspace_id}/repo",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        WorkspaceProxyService,
         "cleanup_workspace",
         lambda self, workspace_id: _workspace().model_copy(
             update={"has_changes": False, "changed_files": []}
@@ -1398,6 +1422,330 @@ def test_resume_run_recovers_interrupted_codex_session(
     assert "codex_resume_requested" in note_kinds
     assert "codex_resume_started" in note_kinds
     assert "codex_resume_completed" in note_kinds
+
+
+def test_rerun_run_creates_fresh_run_from_cancelled_context(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    """Rerun should create a new run with the same task context and a fresh workspace."""
+    headers = _auth_headers(
+        client,
+        email="runner-rerun@example.com",
+        display_name="Runner Rerun",
+    )
+    _publish_agent(
+        client,
+        headers=headers,
+        slug="delivery-orchestrator",
+        title="Delivery Orchestrator",
+    )
+    _publish_team(client, headers=headers, slug="delivery-team-rerun")
+
+    monkeypatch.setattr(
+        HostExecutionReadinessService,
+        "build_readiness",
+        lambda self: SimpleNamespace(effective_ready=True),
+    )
+    monkeypatch.setattr(
+        GitHubProxyService,
+        "get_repo",
+        lambda self, owner, repo: GitHubRepoRead(
+            owner=owner,
+            name=repo,
+            full_name=f"{owner}/{repo}",
+            description="Demo repo",
+            url=f"https://github.com/{owner}/{repo}",
+            is_private=False,
+            default_branch="main",
+        ),
+    )
+
+    workspace_counter = {"value": 0}
+
+    def _next_workspace() -> WorkspaceRead:
+        workspace_counter["value"] += 1
+        index = workspace_counter["value"]
+        return _workspace().model_copy(
+            update={
+                "id": f"ws-{index}",
+                "workspace_path": f"/tmp/ws-{index}",
+                "repo_path": f"/tmp/ws-{index}/repo",
+                "working_branch": f"tap/team-agent-platform/rerun-{index}",
+                "current_branch": f"tap/team-agent-platform/rerun-{index}",
+            }
+        )
+
+    monkeypatch.setattr(
+        WorkspaceProxyService,
+        "prepare_workspace",
+        lambda self, payload: _next_workspace(),
+    )
+    monkeypatch.setattr(
+        WorkspaceProxyService,
+        "materialize_workspace",
+        lambda self, workspace_id, payload: _workspace().model_copy(
+            update={
+                "id": workspace_id,
+                "workspace_path": f"/tmp/{workspace_id}",
+                "repo_path": f"/tmp/{workspace_id}/repo",
+                "working_branch": f"tap/team-agent-platform/{workspace_id}",
+                "current_branch": f"tap/team-agent-platform/{workspace_id}",
+                "has_changes": True,
+                "changed_files": [file.path for file in payload.files],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        WorkspaceProxyService,
+        "get_execution_config",
+        lambda self, workspace_id: _execution_config(),
+    )
+    monkeypatch.setattr(
+        ExportService,
+        "build_download_artifact",
+        lambda self, **kwargs: (
+            "delivery-team-rerun-codex.zip",
+            _bundle_bytes({".codex/config.toml": "[features]\nmulti_agent = true\n"}),
+            "application/zip",
+        ),
+    )
+
+    def _running_session(run_id: str, workspace_id: str) -> CodexSessionRead:
+        return CodexSessionRead(
+            run_id=run_id,
+            workspace_id=workspace_id,
+            repo_path=f"/tmp/{workspace_id}/repo",
+            command=["codex", "exec", "--json"],
+            status="running",
+            pid=12345,
+            codex_session_id=f"session-{run_id}",
+            transport_kind="pty",
+            transport_ref=f"pty-{run_id}",
+            started_at="2026-03-08T10:06:00Z",
+            last_output_offset=0,
+        )
+
+    monkeypatch.setattr(
+        CodexProxyService,
+        "start_session",
+        lambda self, payload: _running_session(payload.run_id, payload.workspace_id),
+    )
+    monkeypatch.setattr(
+        CodexProxyService,
+        "get_session",
+        lambda self, run_id: _running_session(run_id, "ws-source"),
+    )
+    monkeypatch.setattr(
+        CodexProxyService,
+        "get_events",
+        lambda self, run_id, offset: CodexSessionEventsResponse(
+            session=_running_session(run_id, "ws-source"),
+            items=[],
+            next_offset=offset,
+        ),
+    )
+    monkeypatch.setattr(
+        CodexProxyService,
+        "cancel_session",
+        lambda self, run_id: CodexSessionRead(
+            run_id=run_id,
+            workspace_id="ws-source",
+            repo_path="/tmp/ws-source/repo",
+            command=["codex", "exec", "--json"],
+            status="cancelled",
+            pid=12345,
+            codex_session_id=f"session-{run_id}",
+            transport_kind="pty",
+            transport_ref=f"pty-{run_id}",
+            started_at="2026-03-08T10:06:00Z",
+            finished_at="2026-03-08T10:10:00Z",
+            last_output_offset=0,
+        ),
+    )
+
+    create_response = client.post(
+        "/api/v1/runs",
+        headers=headers,
+        json={
+            "team_slug": "delivery-team-rerun",
+            "repo_owner": "stemirkhan",
+            "repo_name": "team-agent-platform",
+            "task_text": "Repeat this task with a fresh run context.",
+            "title": "Repeat run from history",
+            "summary": "Carry the same repo, team, and task context into a new run.",
+            "codex": {
+                "model": "gpt-5.3-codex-spark",
+                "model_reasoning_effort": "high",
+                "sandbox_mode": "workspace-write",
+            },
+        },
+    )
+    assert create_response.status_code == 201
+    source_run = create_response.json()
+    source_run_id = source_run["id"]
+    assert source_run["workspace_id"] == "ws-1"
+
+    cancel_response = client.post(f"/api/v1/runs/{source_run_id}/cancel", headers=headers)
+    assert cancel_response.status_code == 200
+    assert cancel_response.json()["status"] == "cancelled"
+
+    rerun_response = client.post(f"/api/v1/runs/{source_run_id}/rerun", headers=headers)
+    assert rerun_response.status_code == 201
+    rerun_payload = rerun_response.json()
+    assert rerun_payload["id"] != source_run_id
+    assert rerun_payload["status"] == "running"
+    assert rerun_payload["workspace_id"] == "ws-2"
+    assert rerun_payload["working_branch"] == "tap/team-agent-platform/rerun-2"
+    assert rerun_payload["team_slug"] == source_run["team_slug"]
+    assert rerun_payload["repo_full_name"] == source_run["repo_full_name"]
+    assert rerun_payload["task_text"] == source_run["task_text"]
+    assert rerun_payload["title"] == source_run["title"]
+    assert rerun_payload["summary"] == source_run["summary"]
+    assert (
+        rerun_payload["runtime_config_json"]["codex"] == source_run["runtime_config_json"]["codex"]
+    )
+    assert rerun_payload["codex_session_id"] != source_run["codex_session_id"]
+
+    rerun_events_response = client.get(
+        f"/api/v1/runs/{rerun_payload['id']}/events",
+        headers=headers,
+    )
+    assert rerun_events_response.status_code == 200
+    rerun_event = next(
+        item["payload_json"]
+        for item in rerun_events_response.json()["items"]
+        if item["event_type"] == "note"
+        and item["payload_json"]
+        and item["payload_json"].get("kind") == "rerun"
+    )
+    assert rerun_event["source_run_id"] == source_run_id
+
+
+def test_rerun_run_rejects_interrupted_source_run(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    """Interrupted runs must use resume instead of rerun."""
+    headers = _auth_headers(
+        client,
+        email="runner-rerun-blocked@example.com",
+        display_name="Runner Rerun Blocked",
+    )
+    _publish_agent(
+        client,
+        headers=headers,
+        slug="delivery-orchestrator",
+        title="Delivery Orchestrator",
+    )
+    _publish_team(client, headers=headers, slug="delivery-team-rerun-blocked")
+
+    monkeypatch.setattr(
+        HostExecutionReadinessService,
+        "build_readiness",
+        lambda self: SimpleNamespace(effective_ready=True),
+    )
+    monkeypatch.setattr(
+        GitHubProxyService,
+        "get_repo",
+        lambda self, owner, repo: GitHubRepoRead(
+            owner=owner,
+            name=repo,
+            full_name=f"{owner}/{repo}",
+            description="Demo repo",
+            url=f"https://github.com/{owner}/{repo}",
+            is_private=False,
+            default_branch="main",
+        ),
+    )
+    monkeypatch.setattr(
+        WorkspaceProxyService,
+        "prepare_workspace",
+        lambda self, payload: _workspace(),
+    )
+    monkeypatch.setattr(
+        WorkspaceProxyService,
+        "materialize_workspace",
+        lambda self, workspace_id, payload: _workspace().model_copy(
+            update={"has_changes": True, "changed_files": ["TASK.md"]}
+        ),
+    )
+    monkeypatch.setattr(
+        WorkspaceProxyService,
+        "get_execution_config",
+        lambda self, workspace_id: _execution_config(),
+    )
+    monkeypatch.setattr(
+        ExportService,
+        "build_download_artifact",
+        lambda self, **kwargs: (
+            "delivery-team-rerun-blocked-codex.zip",
+            _bundle_bytes({".codex/config.toml": "[features]\nmulti_agent = true\n"}),
+            "application/zip",
+        ),
+    )
+
+    def _session(run_id: str, status: str) -> CodexSessionRead:
+        return CodexSessionRead(
+            run_id=run_id,
+            workspace_id="ws-1",
+            repo_path="/tmp/ws-1/repo",
+            command=["codex", "exec", "--json"],
+            status=status,
+            pid=12345,
+            error_message="Codex session was interrupted.",
+            codex_session_id="session-interrupted",
+            transport_kind="pty",
+            transport_ref="pty-interrupted",
+            interrupted_at="2026-03-08T10:07:00Z" if status == "interrupted" else None,
+            resumable=status == "interrupted",
+            started_at="2026-03-08T10:06:00Z",
+            finished_at="2026-03-08T10:07:00Z" if status == "interrupted" else None,
+            last_output_offset=0,
+        )
+
+    session_state = {"status": "running"}
+    monkeypatch.setattr(
+        CodexProxyService,
+        "start_session",
+        lambda self, payload: _session(payload.run_id, "running"),
+    )
+    monkeypatch.setattr(
+        CodexProxyService,
+        "get_session",
+        lambda self, run_id: _session(run_id, session_state["status"]),
+    )
+    monkeypatch.setattr(
+        CodexProxyService,
+        "get_events",
+        lambda self, run_id, offset: CodexSessionEventsResponse(
+            session=_session(run_id, session_state["status"]),
+            items=[],
+            next_offset=offset,
+        ),
+    )
+
+    create_response = client.post(
+        "/api/v1/runs",
+        headers=headers,
+        json={
+            "team_slug": "delivery-team-rerun-blocked",
+            "repo_owner": "stemirkhan",
+            "repo_name": "team-agent-platform",
+            "task_text": "This run should be resumed, not rerun.",
+        },
+    )
+    assert create_response.status_code == 201
+    run_id = create_response.json()["id"]
+
+    session_state["status"] = "interrupted"
+    interrupted_response = client.get(f"/api/v1/runs/{run_id}", headers=headers)
+    assert interrupted_response.status_code == 200
+    assert interrupted_response.json()["status"] == "interrupted"
+
+    rerun_response = client.post(f"/api/v1/runs/{run_id}/rerun", headers=headers)
+    assert rerun_response.status_code == 409
+    assert "Use resume for interrupted runs." in rerun_response.json()["detail"]
 
 
 def test_get_run_auto_recovers_codex_session_after_host_restart(

--- a/apps/web/src/components/runs/run-details-panel.tsx
+++ b/apps/web/src/components/runs/run-details-panel.tsx
@@ -37,6 +37,7 @@ import {
   fetchRunEvents,
   fetchWorkspace,
   resumeRun,
+  rerunRun,
   type CodexSessionRead,
   type Run,
   type RunEvent,
@@ -500,6 +501,7 @@ export function RunDetailsPanel({ locale, runId }: RunDetailsPanelProps) {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [cancelling, setCancelling] = useState(false);
   const [resumingRun, setResumingRun] = useState(false);
+  const [rerunningRun, setRerunningRun] = useState(false);
   const [activeTab, setActiveTab] = useState<RunPageTabId>("overview");
   const [nowMs, setNowMs] = useState(() => Date.now());
 
@@ -646,6 +648,12 @@ export function RunDetailsPanel({ locale, runId }: RunDetailsPanelProps) {
     }
     return run.status === "interrupted" && terminalSession.resumable;
   }, [run, terminalSession]);
+  const canRerun = useMemo(() => {
+    if (!run) {
+      return false;
+    }
+    return run.status === "completed" || run.status === "failed" || run.status === "cancelled";
+  }, [run]);
   const displaySummary = useMemo(() => {
     const normalized = tryExtractNestedMessage(run?.summary ?? null);
     if (!normalized) {
@@ -733,6 +741,27 @@ export function RunDetailsPanel({ locale, runId }: RunDetailsPanelProps) {
       );
     } finally {
       setResumingRun(false);
+    }
+  }
+
+  async function onRerun() {
+    if (!token || !run) {
+      router.push("/auth/login");
+      return;
+    }
+
+    setRerunningRun(true);
+    setErrorMessage(null);
+    try {
+      const nextRun = await rerunRun(run.id, token);
+      router.push(`/runs/${nextRun.id}`);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : t(locale, { ru: "Не удалось запустить run повторно.", en: "Failed to run again." })
+      );
+      setRerunningRun(false);
     }
   }
 
@@ -1304,6 +1333,16 @@ export function RunDetailsPanel({ locale, runId }: RunDetailsPanelProps) {
                     {t(locale, { ru: "Возобновить Codex", en: "Resume Codex session" })}
                   </Button>
                 ) : null}
+                {canRerun ? (
+                  <Button disabled={rerunningRun} onClick={() => void onRerun()} type="button">
+                    {rerunningRun ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <PlaySquare className="mr-2 h-4 w-4" />
+                    )}
+                    {t(locale, { ru: "Запустить снова", en: "Run again" })}
+                  </Button>
+                ) : null}
                 {canCancel ? (
                   <Button disabled={cancelling} onClick={() => void onCancel()} type="button" variant="ghost">
                     {cancelling ? (
@@ -1315,6 +1354,19 @@ export function RunDetailsPanel({ locale, runId }: RunDetailsPanelProps) {
                   </Button>
                 ) : null}
               </div>
+              {canResume || canRerun ? (
+                <p className="text-sm text-slate-600 dark:text-slate-300">
+                  {canResume
+                    ? t(locale, {
+                        ru: "Resume продолжит прерванную Codex-сессию в этом же run. Run again создаст новый run с новым workspace и branch.",
+                        en: "Resume continues the interrupted Codex session in this same run. Run again creates a fresh run with a new workspace and branch."
+                      })
+                    : t(locale, {
+                        ru: "Run again создает новый run с тем же team, repo и task context, но с новым workspace и branch.",
+                        en: "Run again creates a fresh run with the same team, repo, and task context, but a new workspace and branch."
+                      })}
+                </p>
+              ) : null}
             </div>
           </div>
         </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -887,6 +887,22 @@ export async function resumeRun(runId: string, token: string): Promise<Run> {
   return json as Run;
 }
 
+export async function rerunRun(runId: string, token: string): Promise<Run> {
+  const response = await fetch(`${getApiBaseUrl()}/runs/${runId}/rerun`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+
+  const json = await readResponsePayload(response);
+  if (!response.ok) {
+    throw new Error(extractErrorMessage(json) ?? "Failed to rerun run.");
+  }
+
+  return json as Run;
+}
+
 export async function fetchRunTerminalSession(
   runId: string,
   token: string


### PR DESCRIPTION
## Team Agent Platform run

- Team: `Fullstack Delivery Squad`
- Repository: `stemirkhan/team-agent-platform`
- Base branch: `main`
- Working branch: `tap/team-agent-platform/20260314160145-c13ada`
- Issue: #20
- Issue URL: https://github.com/stemirkhan/team-agent-platform/issues/20

## Summary
Added a fresh rerun flow that stays separate from resume. Backend now exposes `POST /runs/{id}/rerun`, rebuilds a `RunCreate` payload from the original run context, and creates a brand-new run/workspace/branch/session instead of reusing the old terminal session. Frontend now shows a dedicated `Run again` action only for `completed` / `failed` / `cancelled` runs, keeps `Resume Codex session` exclusive to interrupted resumable runs, and navigates straight to the new run after creation.

Main files changed: [runs.py](/home/temirkhan/.team-agent-platform/workspaces/9809abb7c24c46c7a7581e634b83b5e5/repo/apps/backend/app/api/v1/runs.py#L90), [run_service.py](/home/temirkhan/.team-agent-platform/workspaces/9809abb7c24c46c7a7581e634b83b5e5/repo/apps/backend/app/services/run_service.py#L469), [test_runs_api.py](/home/temirkhan/.team-agent-platform/workspaces/9809abb7c24c46c7a7581e634b83b5e5/repo/apps/backend/tests/test_runs_api.py#L1427), [api.ts](/home/temirkhan/.team-agent-platform/workspaces/9809abb7c24c46c7a7581e634b83b5e5/repo/apps/web/src/lib/api.ts#L890), [run-details-panel.tsx](/home/temirkhan/.team-agent-platform/workspaces/9809abb7c24c46c7a7581e634b83b5e5/repo/apps/web/src/components/runs/run-details-panel.tsx#L651).

Validation:
- `make compose-config`
- `cd apps/backend && .venv/bin/python -m ruff check app tests`
- `cd apps/web && npm run lint`

`ruff` and frontend lint passed. I could not complete `cd apps/backend && .venv/bin/python -m pytest -q` in this environment: `pytest` is hanging during `TestClient`-based startup, so backend tests were updated but not fully executed end-to-end here. The next logical step is to run the backend pytest suite in a clean shell/process and verify the two new rerun cases pass without the local `TestClient` hang.

## Notes
- This draft PR was created by the local host-execution flow.
- Review the diff and run project-specific checks before merging.